### PR TITLE
Change webHooks to webhooks in configuration yaml

### DIFF
--- a/denyenv.yaml
+++ b/denyenv.yaml
@@ -2,7 +2,7 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: denyenv
-webHooks:
+webhooks:
   - name: denyenv.hightowerlabs.com
     rules:
       - apiGroups:


### PR DESCRIPTION
current `ValidatingWebhookConfiguration` yaml is invalid (a create returns `unknown field "webHooks" in io.k8s.api.admissionregistration.v1beta1.ValidatingWebhookConfiguration`) - change to match correct field name.