### PR TITLE
minor nit : Update README with new --cluster-version

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Use the `gcloud` command to create the `k0` Kubernetes cluster:
 
 ```
 gcloud container clusters create k0 \
-  --cluster-version 1.9.2-gke.1 \
+  --cluster-version 1.10.11-gke.1 \
   --zone us-central1-a \
   --num-nodes 1
 ```


### PR DESCRIPTION
I got an error when running

`gcloud container clusters create k0 --cluster-version 1.9.2-gke.1 --zone us-central1-a --num-nodes 1`

I removed the --cluster-version from this command and it worked.  Alternately the version could be updated, which is what is in this PR. It looks like the current version is 1.10.11-gke.1